### PR TITLE
foreign key "user_id" type must be bigInteger

### DIFF
--- a/database/migrations/2015_05_06_222534_create_grades_table.php
+++ b/database/migrations/2015_05_06_222534_create_grades_table.php
@@ -15,7 +15,7 @@ class CreateGradesTable extends Migration {
 		Schema::create('grades', function(Blueprint $table)
 		{
 			$table->increments('id');
-			$table->integer('user_id')->unsigned()->unique()->index();
+			$table->bigInteger('user_id')->unsigned()->unique()->index();
 			$table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
 			$table->integer('math')->nullable();
 			$table->integer('english')->nullable();


### PR DESCRIPTION
migrate failed on MariaDB 10.x and MySQL ... I passed migration by change user_id type from Integer to bigInteger, foreign key type must the same as reference column's type
